### PR TITLE
Implement Gmail SMTP email verification and verify page updates

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -157,6 +157,16 @@ STATIC_URL = 'static/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-DEFAULT_FROM_EMAIL = "no-reply@uic-marketplace.dev"
-FRONTEND_ORIGIN = os.environ.get("FRONTEND_ORIGIN", "http://localhost:5173")
+#  Email configuration 
+EMAIL_BACKEND = os.environ.get(
+    "EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend"
+)
+EMAIL_HOST = os.environ.get("EMAIL_HOST", "")
+EMAIL_PORT = int(os.environ.get("EMAIL_PORT", 587))
+EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS", "True") == "True"
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "")
+EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "")
+DEFAULT_FROM_EMAIL = os.environ.get(
+    "DEFAULT_FROM_EMAIL", EMAIL_HOST_USER or "no-reply@uicmarketplace.dev"
+)
+

--- a/frontend/src/Pages/Verify.jsx
+++ b/frontend/src/Pages/Verify.jsx
@@ -8,7 +8,7 @@ export default function Verify() {
   if (status === "success") {
     return (
       <div style={{ maxWidth: 600, margin: "4rem auto", textAlign: "center" }}>
-        <h1>✅ Your email is verified</h1>
+        <h1> Your email is verified</h1>
         <p>You can now sign in to UIC Marketplace.</p>
         <p><Link to="/">Go back to home</Link></p>
       </div>
@@ -18,7 +18,7 @@ export default function Verify() {
   if (status === "failed" || status === "expired") {
     return (
       <div style={{ maxWidth: 600, margin: "4rem auto", textAlign: "center" }}>
-        <h1>❌ Verification failed</h1>
+        <h1> Verification failed</h1>
         <p>The link may be invalid or expired. Please try signing up again.</p>
         <p><Link to="/">Go back to home</Link></p>
       </div>


### PR DESCRIPTION
This update enables real email verification for new user signups.
Configured Django to send emails through Gmail SMTP (using a project Gmail account).
Added environment-based email settings in backend/settings.py to load credentials securely from .env.
Testing Steps:
Run backend server (python manage.py runserver).
Sign up with a valid email on the frontend.
Check inbox for a verification email and confirm account activation.