### PR TITLE
Fix: ignore backend/.env + use 127.0.0.1 for API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ env/
 # --- Environment / Secrets ---
 .env
 
+backend/.env

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -3,7 +3,7 @@ const normalizeBaseUrl = (url) => {
   return url.endsWith("/") ? url.slice(0, -1) : url;
 };
 
-const DEFAULT_BASE_URL = "http://localhost:8000/api";
+const DEFAULT_BASE_URL = "http://127.0.0.1:8000/api";
 
 export const API_BASE_URL =
   normalizeBaseUrl(import.meta.env?.VITE_API_BASE_URL) || DEFAULT_BASE_URL;


### PR DESCRIPTION
Adds correct email verification setup by ignoring backend/.env and switching the frontend API URL to 127.0.0.1 to fix Windows fetch errors