### PR TITLE
Add IDDFS recommendation engine backend endpoint

### DIFF
--- a/backend/services/iddfs.py
+++ b/backend/services/iddfs.py
@@ -1,0 +1,37 @@
+# IDDFS implementation
+
+def iddfs(graph, start, max_depth=3):
+    """
+    Runs IDDFS from `start` up to `max_depth`.
+    Returns a dictionary: depth -> list of IDs
+    """
+    results = {}
+
+    for depth in range(1, max_depth + 1):
+        visited = set()
+        layer = depth_limited_dfs(graph, start, depth, visited)
+        results[depth] = layer
+
+    return results
+
+
+def depth_limited_dfs(graph, node, depth, visited):
+    """
+    Returns all nodes reachable exactly at *this* depth.
+    """
+    if depth == 0:
+        return []
+
+    visited.add(node)
+    results = []
+
+    for neighbor in graph.get(node, []):
+        if neighbor not in visited:
+            if depth == 1:
+                results.append(neighbor)
+            else:
+                results.extend(
+                    depth_limited_dfs(graph, neighbor, depth - 1, visited)
+                )
+
+    return list(set(results))

--- a/backend/services/recommend_utils.py
+++ b/backend/services/recommend_utils.py
@@ -1,0 +1,40 @@
+from .models import Service
+
+def build_similarity_graph():
+    """
+    Build a graph of services based on:
+    - same provider
+    - same location
+    - overlapping words in title
+    """
+    graph = {}
+    services = Service.objects.all()
+
+    # Initialize graph
+    for s in services:
+        graph[s.id] = set()
+
+    # Compare all pairs
+    for s1 in services:
+        for s2 in services:
+            if s1.id == s2.id:
+                continue
+
+            # Same provider
+            if s1.provider_id == s2.provider_id:
+                graph[s1.id].add(s2.id)
+                continue
+
+            # Same location
+            if s1.location.strip().lower() == s2.location.strip().lower():
+                graph[s1.id].add(s2.id)
+                continue
+
+            # Title word overlap
+            t1 = set(s1.title.lower().split())
+            t2 = set(s2.title.lower().split())
+            if len(t1.intersection(t2)) > 0:
+                graph[s1.id].add(s2.id)
+
+    # Convert sets → lists for JSON
+    return {k: list(v) for k, v in graph.items()}


### PR DESCRIPTION
adds a new data structure: an Iterative Deepening Depth-First Search (IDDFS) recommendation system for services. It creates a similarity graph between services and exposes a clean API endpoint that returns related services at multiple depths.
This PR does NOT modify any frontend UI.
Frontend team can choose how/how much to display these recommendations on Service Detail page 
New endpoint:
GET /api/services/<id>/recommendations/
Returns three lists of recommended services:
depth_1 (closest)
depth_2
depth_3
Returns related services based on:
same provider
same location
overlapping keywords
{
  depth_1: [...],
  depth_2: [...],
  depth_3: [...]
}
Frontend usage:
const recs = await fetchRecommendations(serviceId);